### PR TITLE
Add `small.en-tdrz` checkpoint and initial support for `speakerturn` in decoding results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # tinyDiarize 🐥🗣️
 
-This is a lightweight, extension of OpenAI's [whisper](https://github.com/openai/whisper) models that adds speaker diarization to the transcription output via `<speakerturn>` tags. It can be used as a drop-in replacement for `whisper.transcribe` with the same API, no extra dependencies, and the added benefit of speaker diarization.
+This is a minimal extension of OpenAI's [Whisper](https://github.com/openai/whisper) models that adds speaker diarization to the transcription output via `<speakerturn>` tags. It can be used as a drop-in replacement for `whisper.transcribe` with the same API, and no extra dependencies.
+
+```
+whisper AUDIO --model small.en-tdrz SAME_ARGS
+```
 
 ![demo](trim-tinydiarize.gif)
 
-- Whisper checkpoints were finetuned using HuggingFace [transformers](https://github.com/huggingface/transformers) and [datasets](https://github.com/huggingface/datasets) with just 30mins of 1 GPU training :)
+- Whisper checkpoints were finetuned using HuggingFace [Transformers](https://github.com/huggingface/transformers) and [Datasets](https://github.com/huggingface/datasets) with just 30mins of 1 GPU training :)
 - Finetuning code will be released for full reproducibility
 - Includes a scoring setup using [revdotcom/fstalign](https://github.com/revdotcom/fstalign) that allows for easy error inspection and side-by-side analysis
-- Jupyter notebooks and an accompanying blog post will be released soon with more details 
+- Jupyter notebooks and an accompanying blog post will be released soon with more details
 
 Stay tuned! 📺
 

--- a/whisper/__init__.py
+++ b/whisper/__init__.py
@@ -20,6 +20,7 @@ _MODELS = {
     "base.en": "https://openaipublic.azureedge.net/main/whisper/models/25a8566e1d0c1e2231d1c762132cd20e0f96a85d16145c3a00adf5d1ac670ead/base.en.pt",
     "base": "https://openaipublic.azureedge.net/main/whisper/models/ed3a0b6b1c0edf879ad9b11b1af5a0e6ab5db9205f891f668f8b0e6c6326e34e/base.pt",
     "small.en": "https://openaipublic.azureedge.net/main/whisper/models/f953ad0fd29cacd07d5a9eda5624af0f6bcf2258be67c92b79389873d91e0872/small.en.pt",
+    "small.en-tdrz": "https://sharedstorage7190.blob.core.windows.net/tinydiarize/whisper/models/ed000c2c9e9c80eefd25c2b3f2612c8bd18e9be7aa9d171be2c7231dce855354/small.en-tdrz.pt",
     "small": "https://openaipublic.azureedge.net/main/whisper/models/9ecf779972d90ba49c06d968637d720dd632c55bbf19d441fb42bf17a411e794/small.pt",
     "medium.en": "https://openaipublic.azureedge.net/main/whisper/models/d7440d1dc186f76616474e0ff0b3b6b879abc9d1a4926b7adfa41db2d497ab4f/medium.en.pt",
     "medium": "https://openaipublic.azureedge.net/main/whisper/models/345ae4da62f9b3d59415adc60127b97c714f32e89e936602e85993674d08dcb1/medium.pt",
@@ -36,6 +37,7 @@ _ALIGNMENT_HEADS = {
     "base.en": b"ABzY8;40c<0{>%RzzG;p*o+Vo09|#PsxSZm00",
     "base": b"ABzY8KQ!870{>%RzyTQH3`Q^yNP!>##QT-<FaQ7m",
     "small.en": b"ABzY8>?_)10{>%RpeA61k&I|OI3I$65C{;;pbCHh0B{qLQ;+}v00",
+    "small.en-tdrz": None,  # TODO@Akash - check if it changed after finetuning
     "small": b"ABzY8DmU6=0{>%Rpa?J`kvJ6qF(V^F86#Xh7JUGMK}P<N0000",
     "medium.en": b"ABzY8usPae0{>%R7<zz_OvQ{)4kMa0BMw6u5rT}kRKX;$NfYBv00*Hl@qhsU00",
     "medium": b"ABzY8B0Jh+0{>%R7}kK1fFL7w6%<-Pf*t^=N)Qr&0RR9",

--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -617,7 +617,7 @@ class DecodingTask:
                 self.tokenizer.translate,
                 self.tokenizer.sot,
                 self.tokenizer.sot_prev,
-                self.tokenizer.sot_lm,
+                # self.tokenizer.sot_lm,
             ]
         )
         if self.tokenizer.no_speech is not None:

--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -617,7 +617,7 @@ class DecodingTask:
                 self.tokenizer.translate,
                 self.tokenizer.sot,
                 self.tokenizer.sot_prev,
-                # self.tokenizer.sot_lm,
+                # self.tokenizer.speaker_turn,  # TODO@Akash control via user flag
             ]
         )
         if self.tokenizer.no_speech is not None:

--- a/whisper/tokenizer.py
+++ b/whisper/tokenizer.py
@@ -178,7 +178,8 @@ class Tokenizer:
 
     @cached_property
     def sot_lm(self) -> int:
-        return self._get_single_token_id("<|startoflm|>")
+        # return self._get_single_token_id("<|startoflm|>")
+        return self._get_single_token_id("<|speakerturn|>")
 
     @cached_property
     def sot_prev(self) -> int:
@@ -328,7 +329,8 @@ def build_tokenizer(name: str = "gpt2"):
         *[f"<|{lang}|>" for lang in LANGUAGES.keys()],
         "<|translate|>",
         "<|transcribe|>",
-        "<|startoflm|>",
+        # "<|startoflm|>",
+        "<|speakerturn|>",
         "<|startofprev|>",
         "<|nospeech|>",
         "<|notimestamps|>",

--- a/whisper/tokenizer.py
+++ b/whisper/tokenizer.py
@@ -177,8 +177,7 @@ class Tokenizer:
         return self._get_single_token_id("<|startoftranscript|>")
 
     @cached_property
-    def sot_lm(self) -> int:
-        # return self._get_single_token_id("<|startoflm|>")
+    def speaker_turn(self) -> int:  # replaces unused sot_lm token
         return self._get_single_token_id("<|speakerturn|>")
 
     @cached_property
@@ -329,8 +328,7 @@ def build_tokenizer(name: str = "gpt2"):
         *[f"<|{lang}|>" for lang in LANGUAGES.keys()],
         "<|translate|>",
         "<|transcribe|>",
-        # "<|startoflm|>",
-        "<|speakerturn|>",
+        "<|speakerturn|>",  # hack and override "<|startoflm|>"
         "<|startofprev|>",
         "<|nospeech|>",
         "<|notimestamps|>",

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -201,8 +201,11 @@ def transcribe(
         *, start: float, end: float, tokens: torch.Tensor, result: DecodingResult
     ):
         tokens = tokens.tolist()
-        # text_tokens = [token for token in tokens if token < tokenizer.eot]
-        text_tokens = [token for token in tokens if (token < tokenizer.eot) or (token == tokenizer.sot_lm)]
+        text_tokens = [
+            token
+            for token in tokens
+            if (token < tokenizer.eot) or (token == tokenizer.speaker_turn)
+        ]
         return {
             "seek": seek,
             "start": start,
@@ -313,9 +316,9 @@ def transcribe(
             if not condition_on_previous_text or result.temperature > 0.5:
                 # do not feed the prompt tokens if a high temperature was used
                 prompt_reset_since = len(all_tokens)
-            
+
             if verbose:
-                print('--'*10)
+                print("--" * 10)
 
             if word_timestamps:
                 add_word_timestamps(

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -318,7 +318,7 @@ def transcribe(
                 prompt_reset_since = len(all_tokens)
 
             if verbose:
-                print("--" * 10)
+                print("--" * 15)
 
             if word_timestamps:
                 add_word_timestamps(
@@ -381,8 +381,7 @@ def cli():
     # fmt: off
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("audio", nargs="+", type=str, help="audio file(s) to transcribe")
-    # parser.add_argument("--model", default="small", choices=available_models(), help="name of the Whisper model to use")
-    parser.add_argument("--model", default="small", help="name of the Whisper model to use")
+    parser.add_argument("--model", default="small.en-tdrz", choices=available_models(), help="name of the Whisper model to use")
     parser.add_argument("--model_dir", type=str, default=None, help="the path to save model files; uses ~/.cache/whisper by default")
     parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu", help="device to use for PyTorch inference")
     parser.add_argument("--output_dir", "-o", type=str, default=".", help="directory to save the outputs")

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -201,7 +201,8 @@ def transcribe(
         *, start: float, end: float, tokens: torch.Tensor, result: DecodingResult
     ):
         tokens = tokens.tolist()
-        text_tokens = [token for token in tokens if token < tokenizer.eot]
+        # text_tokens = [token for token in tokens if token < tokenizer.eot]
+        text_tokens = [token for token in tokens if (token < tokenizer.eot) or (token == tokenizer.sot_lm)]
         return {
             "seek": seek,
             "start": start,
@@ -249,6 +250,7 @@ def transcribe(
             timestamp_tokens: torch.Tensor = tokens.ge(tokenizer.timestamp_begin)
             single_timestamp_ending = timestamp_tokens[-2:].tolist() == [False, True]
 
+            # TODO@Akash - double check if implicitly missing speaker turns at end of chunk
             consecutive = torch.where(timestamp_tokens[:-1] & timestamp_tokens[1:])[0]
             consecutive.add_(1)
             if len(consecutive) > 0:
@@ -311,6 +313,9 @@ def transcribe(
             if not condition_on_previous_text or result.temperature > 0.5:
                 # do not feed the prompt tokens if a high temperature was used
                 prompt_reset_since = len(all_tokens)
+            
+            if verbose:
+                print('--'*10)
 
             if word_timestamps:
                 add_word_timestamps(
@@ -373,7 +378,8 @@ def cli():
     # fmt: off
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("audio", nargs="+", type=str, help="audio file(s) to transcribe")
-    parser.add_argument("--model", default="small", choices=available_models(), help="name of the Whisper model to use")
+    # parser.add_argument("--model", default="small", choices=available_models(), help="name of the Whisper model to use")
+    parser.add_argument("--model", default="small", help="name of the Whisper model to use")
     parser.add_argument("--model_dir", type=str, default=None, help="the path to save model files; uses ~/.cache/whisper by default")
     parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu", help="device to use for PyTorch inference")
     parser.add_argument("--output_dir", "-o", type=str, default=".", help="directory to save the outputs")


### PR DESCRIPTION
This PR adds a support for a new `--model small.en-tdrz` 

- This model was finetuned to output `<|speakerturn|>` tokens. 
- As a quick hack, it simply replaces the `<|startoflm|>` token that was unused in the original whisper models https://github.com/openai/whisper/discussions/414. This allows keeping the model structure exactly the same.
- Small changes are made to `tokenizer`, `transcribe` and `decoding` so that this special token is not suppressed during decoding.
- A follow up PR will control this via a flag (it is always output right now), and force sample a timestamp token after a predicted speaker turn.